### PR TITLE
Feature/mongodb

### DIFF
--- a/bin/example-cdk.ts
+++ b/bin/example-cdk.ts
@@ -3,6 +3,7 @@ import "source-map-support/register";
 import * as cdk from "@aws-cdk/core";
 import { ExampleCdkAPIEndpointStack } from "../lib/example-cdk-api-endpoint";
 import { ExampleCdkLambdaCronStack } from "../lib/example-cdk-lamda-cron";
+import { ExampleCdkDocDBStack } from "../lib/example-cdk-docdb";
 
 // TODO: env,contextの整理
 const app = new cdk.App();
@@ -29,3 +30,10 @@ new ExampleCdkLambdaCronStack(
     }
   }
 );
+
+new ExampleCdkDocDBStack(app, `ExampleCdkDocDBStack-${env || "dev"}`, {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION
+  }
+});

--- a/cdk.json
+++ b/cdk.json
@@ -2,66 +2,40 @@
   "context": {
     "dev": {
       "description": "Development Example-CDK",
-      "customDomainName": "",
-      "certificateArn": "",
-      "hostedZoneId": "",
-      "bucketName": "",
-      "vpcName": "",
-      "privateSubnets": [
-        {
-          "subnetId": "",
-          "availabilityZone": "ap-northeast-1a",
-          "routeTableId": ""
-        },
-        {
-          "subnetId": "",
-          "availabilityZone": "ap-northeast-1c",
-          "routeTableId": ""
-        }
-      ],
-      "securityGroupID": ""
+      "api": {
+        "customDomainName": "",
+        "certificateArn": "",
+        "hostedZoneId": ""
+      },
+      "lambdaCron": {
+        "bucketName": "",
+        "vpcName": "",
+        "privateSubnets": [
+          {
+            "subnetId": "",
+            "availabilityZone": "ap-northeast-1a",
+            "routeTableId": ""
+          },
+          {
+            "subnetId": "",
+            "availabilityZone": "ap-northeast-1c",
+            "routeTableId": ""
+          }
+        ],
+        "securityGroupID": ""
+      },
+      "docdb": {
+        "dbSubnetGroupName": "",
+        "vpcSecurityGroupIds": [""],
+        "dbInstanceClass": "db.r5.large",
+        "availabilityZone": "ap-northeast-1c"
+      }
     },
     "stg": {
-      "description": "Staging Example-CDK",
-      "customDomainName": "",
-      "certificateArn": "",
-      "hostedZoneId": "",
-      "bucketName": "",
-      "vpcName": "",
-      "privateSubnets": [
-        {
-          "subnetId": "",
-          "availabilityZone": "ap-northeast-1a",
-          "routeTableId": ""
-        },
-        {
-          "subnetId": "",
-          "availabilityZone": "ap-northeast-1c",
-          "routeTableId": ""
-        }
-      ],
-      "securityGroupID": ""
+      "description": "Staging Example-CDK"
     },
     "prd": {
-      "description": "Product Example-CDK",
-      "customDomainName": "",
-      "certificateArn": "",
-      "hostedZoneId": "",
-      "bucketName": "",
-      "vpcName": "",
-      "privateSubnets": [
-        {
-          "subnetId": "",
-          "availabilityZone": "ap-northeast-1a",
-          "routeTableId": ""
-        },
-        {
-          "subnetId": "",
-          "availabilityZone": "ap-northeast-1c",
-          "routeTableId": ""
-        }
-      ],
-      "securityGroupID": ""
+      "description": "Product Example-CDK"
     }
   },
   "app": "npx ts-node bin/example-cdk.ts"

--- a/lib/example-cdk-api-endpoint.ts
+++ b/lib/example-cdk-api-endpoint.ts
@@ -25,7 +25,7 @@ export class ExampleCdkAPIEndpointStack extends cdk.Stack {
       context.hostedZoneId == ""
     ) {
       throw new Error(
-        `error: invalid context:${JSON.stringify({
+        `[${this.stackName}] error: invalid context ${JSON.stringify({
           env,
           revision,
           context

--- a/lib/example-cdk-api-endpoint.ts
+++ b/lib/example-cdk-api-endpoint.ts
@@ -4,11 +4,15 @@ import * as apigateway from "@aws-cdk/aws-apigateway";
 import * as route53 from "@aws-cdk/aws-route53";
 import { Certificate } from "@aws-cdk/aws-certificatemanager";
 
-interface StageContext {
-  description: string;
+interface apiEndpointConfig {
   customDomainName: string;
   certificateArn: string;
   hostedZoneId: string;
+}
+
+interface StageContext {
+  description: string;
+  api: apiEndpointConfig;
 }
 
 export class ExampleCdkAPIEndpointStack extends cdk.Stack {
@@ -20,9 +24,9 @@ export class ExampleCdkAPIEndpointStack extends cdk.Stack {
     const revision: string = this.node.tryGetContext("revision") || "";
     const context: StageContext = this.node.tryGetContext(env) || {};
     if (
-      context.customDomainName == "" ||
-      context.certificateArn == "" ||
-      context.hostedZoneId == ""
+      context.api.customDomainName == "" ||
+      context.api.certificateArn == "" ||
+      context.api.hostedZoneId == ""
     ) {
       throw new Error(
         `[${this.stackName}] error: invalid context ${JSON.stringify({
@@ -52,9 +56,9 @@ export class ExampleCdkAPIEndpointStack extends cdk.Stack {
         certificate: Certificate.fromCertificateArn(
           this,
           `${this.stackName}-Certificate`,
-          context.certificateArn
+          context.api.certificateArn
         ),
-        domainName: context.customDomainName,
+        domainName: context.api.customDomainName,
         endpointType: apigateway.EndpointType.REGIONAL
       }
     );
@@ -68,9 +72,9 @@ export class ExampleCdkAPIEndpointStack extends cdk.Stack {
       zone: route53.HostedZone.fromHostedZoneId(
         this,
         `${this.stackName}-HostedZone`,
-        context.hostedZoneId
+        context.api.hostedZoneId
       ),
-      recordName: `${context.customDomainName}.`,
+      recordName: `${context.api.customDomainName}.`,
       target: route53.AddressRecordTarget.fromAlias({
         bind: (): route53.AliasRecordTargetConfig => ({
           dnsName: domainName.domainNameAliasDomainName,

--- a/lib/example-cdk-docdb.ts
+++ b/lib/example-cdk-docdb.ts
@@ -1,0 +1,48 @@
+import * as cdk from "@aws-cdk/core";
+import * as docdb from "@aws-cdk/aws-docdb";
+
+interface DocDBConfig {
+  dbSubnetGroupName: string;
+  vpcSecurityGroupIds: string[];
+  dbInstanceClass: string;
+  availabilityZone: string;
+}
+interface StageContext {
+  docdb: DocDBConfig;
+}
+
+export class ExampleCdkDocDBStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // TODO: environment from ?
+    const env: string = this.node.tryGetContext("env") || "dev";
+    const revision: string = this.node.tryGetContext("revision") || "";
+    const context: StageContext = this.node.tryGetContext(env) || {};
+    if (!context.docdb) {
+      throw new Error(
+        `[${this.stackName}] error: invalid context ${JSON.stringify({
+          env,
+          revision,
+          context
+        })}`
+      );
+    }
+
+    const userName = "cdktest";
+    const password = "cdktest!temporary";
+    const cluster = new docdb.CfnDBCluster(this, "DocDbCluster", {
+      dbClusterIdentifier: `ExampleCdkDocDBStack-${env}`,
+      masterUsername: userName,
+      masterUserPassword: password,
+      vpcSecurityGroupIds: context.docdb.vpcSecurityGroupIds,
+      dbSubnetGroupName: context.docdb.dbSubnetGroupName
+    });
+
+    let instanceCount: number = 1;
+    new docdb.CfnDBInstance(this, `DocDbInstance${instanceCount++}`, {
+      dbClusterIdentifier: cluster.ref,
+      dbInstanceClass: context.docdb.dbInstanceClass,
+      availabilityZone: context.docdb.availabilityZone
+    });
+  }
+}

--- a/lib/example-cdk-lamda-cron.ts
+++ b/lib/example-cdk-lamda-cron.ts
@@ -32,7 +32,7 @@ export class ExampleCdkLambdaCronStack extends cdk.Stack {
       context.privateSubnets.length == 0
     ) {
       throw new Error(
-        `error: invalid context:${JSON.stringify({
+        `[${this.stackName}] error: invalid context ${JSON.stringify({
           env,
           revision,
           context

--- a/lib/example-cdk-lamda-cron.ts
+++ b/lib/example-cdk-lamda-cron.ts
@@ -11,12 +11,14 @@ interface subnetCongfig {
   availabilityZone: string;
   routeTableId: string;
 }
-
-interface StageContext {
+interface lambdaCronConfig {
   bucketName: string;
   vpcName: string;
   privateSubnets: subnetCongfig[];
   securityGroupID: string;
+}
+interface StageContext {
+  lambdaCron: lambdaCronConfig;
 }
 export class ExampleCdkLambdaCronStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -27,9 +29,9 @@ export class ExampleCdkLambdaCronStack extends cdk.Stack {
     const context: StageContext = this.node.tryGetContext(env) || {};
 
     if (
-      context.bucketName == "" ||
-      context.vpcName == "" ||
-      context.privateSubnets.length == 0
+      context.lambdaCron.bucketName == "" ||
+      context.lambdaCron.vpcName == "" ||
+      context.lambdaCron.privateSubnets.length == 0
     ) {
       throw new Error(
         `[${this.stackName}] error: invalid context ${JSON.stringify({
@@ -43,20 +45,24 @@ export class ExampleCdkLambdaCronStack extends cdk.Stack {
     // create s3 bucket
     const bucket = new s3.Bucket(this, "Bucket", {
       versioned: false,
-      bucketName: context.bucketName,
+      bucketName: context.lambdaCron.bucketName,
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       removalPolicy: cdk.RemovalPolicy.DESTROY
     });
     const getPolicyStatement = new iam.PolicyStatement();
     getPolicyStatement.addActions("s3:GetObject");
-    getPolicyStatement.addResources(`arn:aws:s3:::${context.bucketName}/*`);
+    getPolicyStatement.addResources(
+      `arn:aws:s3:::${context.lambdaCron.bucketName}/*`
+    );
     getPolicyStatement.addServicePrincipal(`logs.${this.region}.amazonaws.com`);
     bucket.addToResourcePolicy(getPolicyStatement);
 
     const putPolicyStatement = new iam.PolicyStatement();
     putPolicyStatement.addActions("s3:PutObject");
-    putPolicyStatement.addResources(`arn:aws:s3:::${context.bucketName}/*`);
+    putPolicyStatement.addResources(
+      `arn:aws:s3:::${context.lambdaCron.bucketName}/*`
+    );
     putPolicyStatement.addServicePrincipal(`logs.${this.region}.amazonaws.com`);
     putPolicyStatement.addCondition("StringEquals", {
       "s3:x-amz-acl": "bucket-owner-full-control"
@@ -65,11 +71,11 @@ export class ExampleCdkLambdaCronStack extends cdk.Stack {
 
     // describe vpc and private subnet and security group
     const vpc = ec2.Vpc.fromLookup(this, "VPC", {
-      vpcId: context.vpcName
+      vpcId: context.lambdaCron.vpcName
     });
 
     const selectSubnets: ec2.SelectedSubnets = vpc.selectSubnets({
-      subnets: context.privateSubnets.map(privateSubnet => {
+      subnets: context.lambdaCron.privateSubnets.map(privateSubnet => {
         return ec2.Subnet.fromSubnetAttributes(this, privateSubnet.subnetId, {
           subnetId: privateSubnet.subnetId,
           availabilityZone: privateSubnet.availabilityZone,
@@ -81,7 +87,7 @@ export class ExampleCdkLambdaCronStack extends cdk.Stack {
     const securityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
       "SecurityGroup",
-      context.securityGroupID
+      context.lambdaCron.securityGroupID
     );
 
     // create lamda to selected vpc and private subnet

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@aws-cdk/aws-apigateway": "1.16.3",
     "@aws-cdk/aws-certificatemanager": "1.16.3",
+    "@aws-cdk/aws-docdb": "1.16.3",
     "@aws-cdk/aws-ec2": "1.16.3",
     "@aws-cdk/aws-events": "1.16.3",
     "@aws-cdk/aws-events-targets": "1.16.3",


### PR DESCRIPTION
## このPRの背景、課題
documentdbを設置するCDKを追加
## 対応事項

<!--
- [ ] fuga
-->

- [x]  CDK: documentdb
- [x]  cdk.jsonをスタックごとに分割
## 特にレビューして欲しい所

N/A
<!--
-
-
-->

## 参考情報
### 確認方法

- cdk.jsonにDocumentDBの情報を記述する(dbSubnetGroupName, vpcSecurityGroupIds,)
dbSubnetGroupName = DocumentDB > サブネットグループ
vpcSecurityGroupIds = VPC > セキュリティグループ

```json

  "context": {
    "dev": {
...
      "docdb": {
        "dbSubnetGroupName": "****", 
        "vpcSecurityGroupIds": ["***"],
        "dbInstanceClass": "db.r5.large",
        "availabilityZone": "ap-northeast-1c"
      }
...


```
```shell
export CDK_DEFAULT_ACCOUNT="*****" \
export CDK_DEFAULT_REGION="ap-northeast-1" \
make deploy APP_ENV=dev STACK_NAME=ExampleCdkDocDBStack
make destroy APP_ENV=dev STACK_NAME=ExampleCdkDocDBStack
```
